### PR TITLE
SBT2.x and Scala 3.8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Install Java And Sbt
-        uses: olafurpg/setup-scala@v14
+      - name: Install Java
+        uses: actions/setup-java@v4
         with:
-          java-version: corretto@1.17
+          distribution: corretto
+          java-version: 17
+      - name: Install Sbt
+        uses: sbt/setup-sbt@v1
       - name: Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Install Java And Sbt
-        uses: olafurpg/setup-scala@v14
+      - name: Install Java
+        uses: actions/setup-java@v4
         with:
-          java-version: corretto@1.17
+          distribution: corretto
+          java-version: 17
+      - name: Install Sbt
+        uses: sbt/setup-sbt@v1
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,7 +7,7 @@
 ### (All comments with ### will be filtered out during template rendering)
 ### ----------------------------------------------------------------------
 
-version=3.9.10
+version=3.11.1
 
 maxColumn = 140
 style = default
@@ -26,7 +26,6 @@ rewrite.rules = [
   AvoidInfix
   RedundantBraces
   RedundantParens
-  AsciiSortImports
   PreferCurlyFors
   SortModifiers
   Imports

--- a/README.md
+++ b/README.md
@@ -62,14 +62,16 @@ When SBT loads your project, the [LaserDiscDefaultsPlugin](src/main/scala/laserd
   * ```sbt
     import laserdisc.sbt.CompileTarget
 
-    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala2Only   // builds only for scala 2
-    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala3Only   // builds only for scala 3 (default) 
-    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala2And3   // cross compile both
+    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala3Only      // default! 
+    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala2Only
+    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala3LTSOnly 
+    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala2And3
+    ThisBuild / laserdiscCompileTarget := CompileTarget.Scala2And3LTS
     ```
     Remember that you need to use `+` in front of compilation-triggering tasks to trigger cross-compilation.
     The `build` alias added by this plugin automatically invokes `+test`.
 * Apply our standard set of `scalacOptions` compiler and linting configurations (for each scala version). 
-  * This includes `-Xfatal-warnings` which fails the build by default if warnings are present.
+  * This includes warnings-as-errors (via `-Werror` for Scala 3 and Scala 2.13+, or `-Xfatal-warnings` for older Scala 2) which fails the build by default if warnings are present.
     * This can be disabled via two mechanisms:
         * `set ThisBuild / laserdiscFailOnWarn := false` in the top level of your `build.sbt` (don't check this in!)
         * passing `-DlaserdiscFailOnWarn=false` as [a SBT option](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html#sbt+JVM+options+and+system+properties) (useful for local dev)

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 ThisBuild / organization     := "io.laserdisc"
 ThisBuild / organizationName := "LaserDisc"
 
-ThisBuild / scalaVersion := "2.12.21"
+ThisBuild / scalaVersion := "3.8.4"
 
-ThisBuild / sbtPluginPublishLegacyMavenStyle := false // since Jun 25, maven central rejects inconsistent POMs
+Global / excludeLintKeys ++= Set(git.gitUncommittedChanges, git.gitDescribedVersion)
 
 lazy val root = (project in file("."))
   .aggregate(`plugin`, `plugin-shared`)
@@ -47,13 +47,13 @@ lazy val `plugin-shared` = project
     compileSettings,
     publishSettings,
     Compile / resourceGenerators += FileTemplates.copyToResources, // crucial for templating - see function comment
-    addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"        % "2.5.6"),
-    addSbtPlugin("com.github.sbt"                    % "sbt-git"             % "2.1.0"),
-    addSbtPlugin("com.github.sbt"                    % "sbt-native-packager" % "1.11.7"),
-    addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"    % "3.0.2"),
+    addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.6.1"),
+    addSbtPlugin("com.github.sbt" % "sbt-git"             % "2.1.0"),
+    addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7"),
+    addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.3+10-a67392d4"), // oldest release with an sbt 2.x artifact
     libraryDependencies += "org.apache.maven" % "maven-artifact" % "3.9.12"
   )
-  .enablePlugins(SbtPlugin, JavaAppPackaging, ScalafmtPlugin, GitPlugin)
+  .enablePlugins(SbtPlugin, ScalafmtPlugin, GitPlugin)
 
 def compileSettings = Seq(
   scalacOptions ++= Seq(
@@ -65,23 +65,21 @@ def compileSettings = Seq(
     "-language:higherKinds",         // allow higher kinded types without `import scala.language.higherKinds`
     "-language:implicitConversions", // allow use of implicit conversions
     "-language:postfixOps",          // enable postfix ops
-    "-Xlint:_,",                     // enable handy linter warnings
-    "-Ywarn-macros:after",           // allows the compiler to resolve implicit imports being flagged as unused
-    "-Xfatal-warnings"               // fail the build if there are warnings
+    "-Wunused:all",                  // enable linter warnings for unused code
+    "-Werror"                        // fail the build if there are warnings
   )
 )
 
 lazy val publishSettings = Seq(
-  Test / publishArtifact := false,
-  pomIncludeRepository   := (_ => false),
-  homepage               := Some(url("http://laserdisc.io/sbt-laserdisc-defaults")),
-  developers             := List(Developer("barryoneill", "Barry O'Neill", "", url("https://github.com/barryoneill"))),
-  publishMavenStyle      := true,
-  scmInfo                := Some(
+  pomIncludeRepository := (_ => false),
+  homepage             := Some(url("http://laserdisc.io/sbt-laserdisc-defaults")),
+  developers           := List(Developer("barryoneill", "Barry O'Neill", "", url("https://github.com/barryoneill"))),
+  publishMavenStyle    := true,
+  scmInfo              := Some(
     ScmInfo(
       url("https://github.com/laserdisc-io/sbt-laserdisc-defaults/tree/master"),
       "scm:git:git@github.com:laserdisc-io/sbt-laserdisc-defaults.git"
     )
   ),
-  licenses := Seq("MIT" -> url("https://raw.githubusercontent.com/laserdisc-io/sbt-laserdisc-defaults/master/LICENSE"))
+  licenses := Seq(License("MIT", url("https://raw.githubusercontent.com/laserdisc-io/sbt-laserdisc-defaults/master/LICENSE")))
 )

--- a/plugin-shared/src/main/scala/laserdisc/sbt/CompileTarget.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/CompileTarget.scala
@@ -1,19 +1,23 @@
 package laserdisc.sbt
 
 /** This enumeration allows the plugin user to specify whether their project
-  * will compile for Scala 2, Scala 3, or cross-compile for both.
+  * will compile for Scala 2, Scala 3 (latest), Scala 3 LTS, or cross-compile for a combination thereof.
   */
 sealed abstract class CompileTarget(val defaultScalaVersion: String, val crossVersions: Seq[String])
 object CompileTarget {
 
-  val Scala2Version: String = "2.13.18"
-  val Scala3Version: String = "3.3.7"
+  val Scala2Version: String    = "2.13.18"
+  val Scala3Version: String    = "3.8.4"
+  val Scala3LTSVersion: String = "3.3.8"
 
-  final case object Scala2Only extends CompileTarget(Scala2Version, List(Scala2Version))
+  case object Scala2Only extends CompileTarget(Scala2Version, List(Scala2Version))
 
-  final case object Scala3Only extends CompileTarget(Scala3Version, List(Scala3Version))
+  case object Scala3Only extends CompileTarget(Scala3Version, List(Scala3Version))
 
-  // cross compiles, but defaults to scala 3 (affects mostly IDE auto-config)
-  final case object Scala2And3 extends CompileTarget(Scala3Version, List(Scala2Version, Scala3Version))
+  case object Scala3LTSOnly extends CompileTarget(Scala3LTSVersion, List(Scala3LTSVersion))
+
+  case object Scala2And3 extends CompileTarget(Scala3Version, List(Scala2Version, Scala3Version))
+
+  case object Scala2And3LTS extends CompileTarget(Scala3Version, List(Scala2Version, Scala3LTSVersion))
 
 }

--- a/plugin-shared/src/main/scala/laserdisc/sbt/DefaultsCategory.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/DefaultsCategory.scala
@@ -12,7 +12,7 @@ trait DefaultsCategory {
     s"$msg [${cause.getClass.getSimpleName}:${cause.getMessage}]"
   )
 
-  protected[this] val logger = Keys.sLog
+  protected val logger = Keys.sLog
 
   /** @return build level settings to be applied
     */

--- a/plugin-shared/src/main/scala/laserdisc/sbt/LaserDiscDefaultsPluginBase.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/LaserDiscDefaultsPluginBase.scala
@@ -1,6 +1,8 @@
 package laserdisc.sbt
 
 import com.github.sbt.git.GitVersioning
+import com.github.sbt.git.SbtGit.GitKeys
+import com.typesafe.sbt.packager.Keys as PackagerKeys
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 import org.scalafmt.sbt.ScalafmtPlugin
 import sbt.*
@@ -25,6 +27,24 @@ abstract class LaserDiscDefaultsPluginBase extends AutoPlugin {
 
   // we're forcing the plugins to be present above, but still, we define them all as requirements
   override def trigger: PluginTrigger = allRequirements
+
+  /* sbt-git and sbt-native-packager (forced on consumer builds via `requires` above) add
+   * settings that SBT2's lintUnused flags as "not used by any other settings/tasks"
+   * We exclude them here to prevent the warnings in all downstream projects */
+  override lazy val globalSettings: Seq[Def.Setting[?]] = Seq(
+    Keys.excludeLintKeys ++= Set(
+      Keys.version,
+      Keys.name,
+      Keys.sourceDirectory,
+      GitKeys.gitUncommittedChanges,
+      GitKeys.gitDescribedVersion,
+      GitKeys.useGitDescribe,
+      GitKeys.versionProperty,
+      PackagerKeys.executableScriptName,
+      PackagerKeys.daemonStdoutLogFile,
+      PackagerKeys.rpmScriptsDirectory
+    )
+  )
 
   // apply these to the whole build (i.e. `ThisBuild / whatever..`)
   override lazy val buildSettings: Seq[Def.Setting[?]] = categories.flatMap(_.buildSettings)

--- a/plugin-shared/src/main/scala/laserdisc/sbt/PublishDefaults.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/PublishDefaults.scala
@@ -2,7 +2,7 @@ package laserdisc.sbt
 
 import laserdisc.sbt.io.readFile
 import sbt.librarymanagement.License.MIT
-import sbt.{Logger, ScmInfo, URL, file, url}
+import sbt.{file, url, Logger, ScmInfo, URI}
 
 /** Used to define plugin-wide defaults related to packaging and identity
   */
@@ -17,7 +17,7 @@ trait PublishDefaults {
   /** Get the homepage associated with this plugin
     * @param repoName The repository name for the current project, which might be useful for building a repo-based URL
     */
-  def homepage(repoName: String): URL
+  def homepage(repoName: String): URI
 
   /** @return The SCM information used when building deployable packages
     */
@@ -31,7 +31,7 @@ trait PublishDefaults {
 trait GithubPublishDefaults extends PublishDefaults {
   def githubOrg: String
 
-  override def homepage(repoName: String): URL = url(s"https://github.com/$githubOrg/$repoName")
+  override def homepage(repoName: String): URI = url(s"https://github.com/$githubOrg/$repoName")
 
   override def scmInfo(repoName: String, gitBranch: String): ScmInfo = ScmInfo(
     url(s"https://github.com/$githubOrg/$repoName/tree/$gitBranch"),

--- a/plugin-shared/src/main/scala/laserdisc/sbt/category/Compiler.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/category/Compiler.scala
@@ -10,7 +10,8 @@ object Compiler {
   private val CompileTargetDefault: CompileTarget = Scala3Only
 
   val FailOnWarnKeyDesc: String    = s"Fail the build if any warnings are present (default: $FailOnWarnDefault)"
-  val CompileTargetKeyDesc: String = s"'Scala2Only', 'Scala3Only', or 'Scala2And3' to cross-compile (default:$CompileTargetDefault)"
+  val CompileTargetKeyDesc: String =
+    s"One of:[Scala2Only,Scala3Only,Scala3LTSOnly], or to cross compile:[Scala2And3,Scala2And3LTS].  Default is:$CompileTargetDefault"
 }
 
 /** Applies scala compiler settings, including scala version and compiler flags
@@ -26,7 +27,7 @@ case class Compiler(
   import laserdisc.sbt.category.Compiler.*
 
   private object ScalacFlags {
-    def Common(failOnWarn: Boolean): Seq[String] = Seq(
+    def Common(failOnWarn: Boolean, currentScalaVersion: String): Seq[String] = Seq(
       "-encoding",
       "UTF-8",
       "-deprecation",
@@ -34,17 +35,31 @@ case class Compiler(
       "-feature",
       "-language:existentials,experimental.macros,higherKinds,implicitConversions,postfixOps"
     ) ++
-      (if (failOnWarn) Seq("-Xfatal-warnings") else Seq())
+      (if (failOnWarn) Seq(FailOnWarnFlag(currentScalaVersion)) else Seq())
+
+    private def FailOnWarnFlag(currentScalaVersion: String): String =
+      CrossVersion.partialVersion(currentScalaVersion) match {
+        case Some((3, _))                    => "-Werror"
+        case Some((2, minor)) if minor >= 13 => "-Werror"
+        case _                               => "-Xfatal-warnings"
+      }
 
     // remove -Wconf:src filter should be available in scala 3.5.x
-    lazy val Version3x: Seq[String] = Seq(
+    def Version3x(currentScalaVersion: String): Seq[String] = Seq(
       "-Yretain-trees",
       "-Xmax-inlines:100",
-      "-Ykind-projector:underscores",
+      Scala3KindProjectorFlag(currentScalaVersion),
       "-source:future",
       "-language:adhocExtensions",
       "-Wconf:msg=`= _` has been deprecated; use `= uninitialized` instead.:s"
     )
+
+    // Scala 3 LTS (3.3.x) keeps the old flag spelling, newer Scala 3 uses -Xkind-projector.
+    private def Scala3KindProjectorFlag(currentScalaVersion: String): String =
+      CrossVersion.partialVersion(currentScalaVersion) match {
+        case Some((3, minor)) if minor <= 3 => "-Ykind-projector:underscores"
+        case _                              => "-Xkind-projector:underscores"
+      }
 
     lazy val Version2_13: Seq[String] = Seq(
       "-Xlint:-unused,_",
@@ -77,10 +92,10 @@ case class Compiler(
   }
 
   override def projectSettings: Seq[Def.Setting[?]] = Seq(
-    scalacOptions ++= ScalacFlags.Common(failOnWarnKey.value),
+    scalacOptions ++= ScalacFlags.Common(failOnWarnKey.value, scalaVersion.value),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, _))                    => ScalacFlags.Version3x
+        case Some((3, _))                    => ScalacFlags.Version3x(scalaVersion.value)
         case Some((2, minor)) if minor >= 13 => ScalacFlags.Version2_13
         case _                               => Seq.empty
       }

--- a/plugin-shared/src/main/scala/laserdisc/sbt/category/Publishing.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/category/Publishing.scala
@@ -2,6 +2,7 @@ package laserdisc.sbt.category
 
 import com.github.sbt.git.ReadableGit
 import com.github.sbt.git.SbtGit.GitKeys.gitReader
+import com.typesafe.sbt.packager.Keys.maintainer
 import laserdisc.sbt.{DefaultsCategory, PluginContext, PublishDefaults}
 import sbt.*
 import sbt.Keys.*
@@ -32,8 +33,9 @@ case class Publishing(
       pomIncludeRepository := (_ => false),
       organization         := publishDefaultsKey.value.groupId,
       organizationName     := publishDefaultsKey.value.orgName,
-      homepage             := publishDefaultsKey.value.homepage(repoNameKey.value).some,
-      scmInfo              := publishDefaultsKey.value.scmInfo(repoNameKey.value, getBranchName(gitReader.value)).some,
+      maintainer           := publishDefaultsKey.value.orgName,
+      homepage             := Some(publishDefaultsKey.value.homepage(repoNameKey.value)),
+      scmInfo              := Some(publishDefaultsKey.value.scmInfo(repoNameKey.value, getBranchName(gitReader.value))),
       licenses             := publishDefaultsKey.value.licenseCheck.validate(licenses.value, logger.value)
     )
 

--- a/plugin-shared/src/main/scala/laserdisc/sbt/category/SbtVersion.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/category/SbtVersion.scala
@@ -2,14 +2,13 @@ package laserdisc.sbt.category
 
 import laserdisc.sbt.*
 import laserdisc.sbt.category.SbtVersion.*
-import laserdisc.sbt.io.{FileTemplater, readResourceStream}
+import laserdisc.sbt.io.{readResourceStream, FileTemplater}
 import org.apache.maven.artifact.versioning.ComparableVersion
 import sbt.*
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, InputStream}
 import java.util.Properties
-import scala.collection.JavaConverters.*
-import scala.tools.nsc.interpreter.InputStream
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 object SbtVersion {

--- a/plugin-shared/src/main/scala/laserdisc/sbt/category/Standards.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/category/Standards.scala
@@ -13,7 +13,7 @@ case class Standards()(implicit val ctx: PluginContext) extends DefaultsCategory
   private lazy val laserdiscCheckForCodeOwners = taskKey[Unit]("Check that the repo has a valid CODEOWNERS file")
 
   override def projectSettings: Seq[Def.Setting[?]] = Seq(
-    laserdiscCheckForCodeOwners := {
+    laserdiscCheckForCodeOwners := Def.uncached {
       val target = file("CODEOWNERS")
       verifyNonEmptyFileExists(
         log = log.value,

--- a/plugin-shared/src/main/scala/laserdisc/sbt/category/package.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/category/package.scala
@@ -1,10 +1,10 @@
 package laserdisc.sbt
 
-import sbt.{Logger, SettingKey, URL}
+import sbt.{Logger, SettingKey}
 
 package object category {
 
-  type License = (String, URL)
+  type License = _root_.sbt.librarymanagement.License
 
   def getSystemPropBoolean(sk: SettingKey[?], default: Boolean, logger: Logger)(implicit ctx: PluginContext): Boolean = {
     val name = sk.key.label

--- a/plugin-shared/src/main/scala/laserdisc/sbt/io/FileTemplater.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/io/FileTemplater.scala
@@ -20,7 +20,7 @@ abstract class FileTemplater {
     */
   def outputFile: File
 
-  private[this] def stripCommentary(in: Seq[String]): Seq[String] =
+  private def stripCommentary(in: Seq[String]): Seq[String] =
     in.dropWhile(_.isBlank).filter(!_.matches("^\\s*###.*$"))
 
   // names have to be unique, so let's use the impl class name

--- a/plugin-shared/src/main/scala/laserdisc/sbt/io/package.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/io/package.scala
@@ -25,7 +25,7 @@ package object io {
   def readResourceLines(log: Logger, resource: String)(implicit ctx: PluginContext): List[String] =
     Try {
       log.pluginDebug(s"Attempting to load resource '$resource'")
-      Source.fromResource(resource, getClass.getClassLoader).getLines().toList
+      Source.fromResource(resource, classOf[PluginContext].getClassLoader).getLines().toList
     } match {
       case Success(value) => value
       case Failure(e)     => fail(s"Failed to load resource $resource", e)
@@ -33,7 +33,7 @@ package object io {
 
   def readResourceStream(log: Logger, resource: String)(implicit ctx: PluginContext): InputStream = {
     log.pluginDebug(s"Attempting to load resource stream '$resource'")
-    val res = getClass.getClassLoader.getResourceAsStream(resource)
+    val res = classOf[PluginContext].getClassLoader.getResourceAsStream(resource)
     if (res == null) {
       throw new IllegalArgumentException(s"Resource '$resource' not found")
     }

--- a/plugin-shared/src/main/scala/laserdisc/sbt/package.scala
+++ b/plugin-shared/src/main/scala/laserdisc/sbt/package.scala
@@ -4,7 +4,7 @@ import _root_.sbt.*
 
 package object sbt {
 
-  type PublishLicense = (String, URL)
+  type PublishLicense = _root_.sbt.librarymanagement.License
 
   object UsefulURLs {
 
@@ -24,7 +24,7 @@ package object sbt {
   // add some consistency to the logs
   implicit class LoggerOps(val logger: Logger) extends AnyVal {
 
-    private[this] def fmt(msg: String)(implicit ctx: PluginContext): String = s"[${ctx.pluginName}] $msg"
+    private def fmt(msg: String)(implicit ctx: PluginContext): String = s"[${ctx.pluginName}] $msg"
 
     def pluginDebug(value: String)(implicit ctx: PluginContext): Unit = logger.debug(fmt(value))
 

--- a/plugin/src/main/scala/laserdisc/sbt/LaserDiscDevelopers.scala
+++ b/plugin/src/main/scala/laserdisc/sbt/LaserDiscDevelopers.scala
@@ -1,6 +1,6 @@
 package laserdisc.sbt
 
-import sbt.{Developer, url}
+import sbt.{url, Developer}
 
 /** Convenience so we don't have to repeat all this info in each laserdisc project
   */

--- a/plugin/src/sbt-test/sbt-laserdisc-defaults/compiler-scalac-defaults/build.sbt
+++ b/plugin/src/sbt-test/sbt-laserdisc-defaults/compiler-scalac-defaults/build.sbt
@@ -1,22 +1,35 @@
+import com.github.sbt.git.DefaultReadableGit
+import com.github.sbt.git.SbtGit.GitKeys.gitReader
 import complete.DefaultParsers.*
 import org.scalatest.matchers.should.Matchers.*
-
+import laserdisc.sbt.CompileTarget.*
 import java.nio.file.Files
-import scala.collection.JavaConverters.*
-import com.github.sbt.git.SbtGit.GitKeys.gitReader
-import com.github.sbt.git.DefaultReadableGit
+import scala.jdk.CollectionConverters.*
 
 ThisBuild / laserdiscRepoName := "sbt-laserdisc-defaults"
 
 // during scripted tests, the root of the project will not be the root of the repo so the git plugin will fail - this works around it
-val ProjectRoot = sys.props.getOrElse("plugin.project.rootdir", sys.error("expected system property \"plugin.project.rootdir\" to be provided"))
-ThisProject / gitReader :=  new DefaultReadableGit(file(ProjectRoot),None)
+val ProjectRoot = sys.props.getOrElse(
+  "plugin.project.rootdir",
+  sys.error("expected system property \"plugin.project.rootdir\" to be provided")
+)
+ThisProject / gitReader := new DefaultReadableGit(file(ProjectRoot), None)
 
 lazy val root = (project in file("."))
   .enablePlugins(LaserDiscDefaultsPlugin)
   .settings(
-
     InputKey[Unit]("hasCompilerFlags") := {
+
+      val expectedFailOnWarnFlag = CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _))                     => "-Werror"
+        case Some((2, minor)) if minor >= 13 => "-Werror"
+        case _                                => "-Xfatal-warnings"
+      }
+
+      val expectedScala3KindProjectorFlag = CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, minor)) if minor <= 3 => "-Ykind-projector:underscores"
+        case _                              => "-Xkind-projector:underscores"
+      }
 
       val commonExpected = List(
         "-encoding",
@@ -25,7 +38,7 @@ lazy val root = (project in file("."))
         "-unchecked",
         "-feature",
         "-language:existentials,experimental.macros,higherKinds,implicitConversions,postfixOps",
-        "-Xfatal-warnings"
+        expectedFailOnWarnFlag
       )
 
       spaceDelimited("<arg>").parsed.headOption
@@ -53,7 +66,7 @@ lazy val root = (project in file("."))
             commonExpected ++ List(
               "-Yretain-trees",
               "-Xmax-inlines:100",
-              "-Ykind-projector:underscores",
+              expectedScala3KindProjectorFlag,
               "-source:future",
               "-language:adhocExtensions",
               "-Wconf:msg=`= _` has been deprecated; use `= uninitialized` instead.:s"
@@ -65,10 +78,12 @@ lazy val root = (project in file("."))
     },
     InputKey[Unit]("hasCompileOutput") := {
 
-      val Scala2Class  = "target/scala-2.13/classes/foo/Test2Thing.class"
-      val Scala3Class  = "target/scala-3.3.7/classes/foo/Test3Thing.class"
-      val Scala2Common = "target/scala-2.13/classes/foo/TestCommonThing.class"
-      val Scala3Common = "target/scala-3.3.7/classes/foo/TestCommonThing.class"
+      val Scala2Class     = s"target/out/jvm/scala-${Scala2Version}/root/classes/foo/Test2Thing.class"
+      val Scala3Class     = s"target/out/jvm/scala-${Scala3Version}/root/classes/foo/Test3Thing.class"
+      val Scala3LTSClass  = s"target/out/jvm/scala-${Scala3LTSVersion}/root/classes/foo/Test3Thing.class"
+      val Scala2Common    = s"target/out/jvm/scala-${Scala2Version}/root/classes/foo/TestCommonThing.class"
+      val Scala3Common    = s"target/out/jvm/scala-${Scala3Version}/root/classes/foo/TestCommonThing.class"
+      val Scala3LTSCommon = s"target/out/jvm/scala-${Scala3LTSVersion}/root/classes/foo/TestCommonThing.class"
 
       spaceDelimited("<arg>").parsed.headOption
         .getOrElse(throw new MessageOnlyException("Missing argument for 'hasCompileOutput'")) match {
@@ -76,18 +91,30 @@ lazy val root = (project in file("."))
         case "shouldOnlyCompileForScala2" =>
           checkFor(
             expected = List(Scala2Common, Scala2Class),
-            notExpected = List(Scala3Common, Scala3Class)
+            notExpected = List(Scala3Common, Scala3LTSCommon, Scala3Class, Scala3LTSClass)
           )
 
         case "shouldOnlyCompileForScala3" =>
           checkFor(
             expected = List(Scala3Common, Scala3Class),
-            notExpected = List(Scala2Common, Scala2Class)
+            notExpected = List(Scala2Common, Scala2Class, Scala3LTSClass, Scala3LTSCommon)
+          )
+
+        case "shouldOnlyCompileForScala3LTS" =>
+          checkFor(
+            expected = List(Scala3LTSCommon, Scala3LTSClass),
+            notExpected = List(Scala2Common, Scala2Class, Scala3Common, Scala3Class)
           )
 
         case "shouldCrossCompileFor2And3" =>
           checkFor(
             expected = List(Scala2Common, Scala3Common, Scala2Class, Scala3Class),
+            notExpected = List()
+          )
+
+        case "shouldCrossCompileFor2And3LTS" =>
+          checkFor(
+            expected = List(Scala2Common, Scala3LTSCommon, Scala2Class, Scala3LTSClass),
             notExpected = List()
           )
 
@@ -97,7 +124,7 @@ lazy val root = (project in file("."))
 
       def checkFor(expected: List[String], notExpected: List[String]): Unit = {
 
-        val allClassFiles = Files
+        val foundClassFiles = Files
           .walk(file("target").toPath)
           .iterator()
           .asScala
@@ -106,14 +133,17 @@ lazy val root = (project in file("."))
           .filter(_.endsWith("class"))
           .toList
 
-        val found = "\n" + allClassFiles.map(s => s"found - ${s}").mkString("\n")
+        val found = "\n" + foundClassFiles.map(s => s"found - ${s}").mkString("\n")
 
-        for (f <- expected if !allClassFiles.contains(f))
-          throw new MessageOnlyException(s"Could not find expected classfile '$f' in compiled output:$found")
+        expected.foreach { filename =>
+          if (!foundClassFiles.exists(_ == filename))
+            throw new MessageOnlyException(s"Could not find expected classfile '$filename' in compiled output:$found")
+        }
 
-        for (f <- notExpected if allClassFiles.contains(f))
-          throw new MessageOnlyException(s"Did not expect to see '$f' in compiled output:$found")
-
+        notExpected.foreach { filename =>
+          if (foundClassFiles.exists(_ == filename))
+            throw new MessageOnlyException(s"Did not expect to find classfile '$filename' in compiled output:$found")
+        }
       }
     }
   )

--- a/plugin/src/sbt-test/sbt-laserdisc-defaults/compiler-scalac-defaults/test
+++ b/plugin/src/sbt-test/sbt-laserdisc-defaults/compiler-scalac-defaults/test
@@ -8,26 +8,43 @@
 
 # ------------------------------------------------------------------------------------------
 # should be the same when the flag is explicitly set for scala 3
+# (note: sbt 2.x `clean` only cleans the active scala version's output in the unified target
+#  directory, so delete it entirely to avoid leftovers from the previous scenario)
 > set ThisBuild / laserdiscCompileTarget := laserdisc.sbt.CompileTarget.Scala3Only
-> clean
+$ delete target
 > +compile
 > hasCompilerFlags 3
 > hasCompileOutput shouldOnlyCompileForScala3
 
 # ------------------------------------------------------------------------------------------
+# check that only scala3 LTS output is generated
+> set ThisBuild / laserdiscCompileTarget := laserdisc.sbt.CompileTarget.Scala3LTSOnly
+$ delete target
+> +compile
+> hasCompilerFlags 3
+> hasCompileOutput shouldOnlyCompileForScala3LTS
+
+# ------------------------------------------------------------------------------------------
 # check that only scala2 output is generated
 > set ThisBuild / laserdiscCompileTarget := laserdisc.sbt.CompileTarget.Scala2Only
-> clean
+$ delete target
 > +compile
 > hasCompilerFlags 2
 > hasCompileOutput shouldOnlyCompileForScala2
 
 # ------------------------------------------------------------------------------------------
-# check that cross compiling works
+# check that cross compiling 2 & 3 works
 > set ThisBuild / laserdiscCompileTarget := laserdisc.sbt.CompileTarget.Scala2And3
-> clean
+$ delete target
 > +compile
 > hasCompileOutput shouldCrossCompileFor2And3
+
+# ------------------------------------------------------------------------------------------
+# check that cross compiling 2 & 3 LTS works
+> set ThisBuild / laserdiscCompileTarget := laserdisc.sbt.CompileTarget.Scala2And3LTS
+$ delete target
+> +compile
+> hasCompileOutput shouldCrossCompileFor2And3LTS
 
 # ------------------------------------------------------------------------------------------
 # the "build" alias should also invoke +compile for cross compilation

--- a/plugin/src/sbt-test/sbt-laserdisc-defaults/templating/build.sbt
+++ b/plugin/src/sbt-test/sbt-laserdisc-defaults/templating/build.sbt
@@ -2,7 +2,7 @@ import complete.DefaultParsers.*
 
 import java.io.ByteArrayInputStream
 import java.util.Properties
-import scala.collection.JavaConverters.*
+import scala.jdk.CollectionConverters.*
 import scala.util.{Failure, Success, Try}
 
 ThisBuild / laserdiscRepoName := "sbt-laserdisc-defaults"

--- a/project/FileTemplates.scala
+++ b/project/FileTemplates.scala
@@ -14,7 +14,7 @@ object FileTemplates {
     * This function copies the files in use by this project into managed resources, so
     * they'll be bundled into the plugin zip distribution.
     */
-  def copyToResources: Def.Initialize[Task[List[File]]] = Def.task {
+  def copyToResources: Def.Initialize[Task[Seq[File]]] = Def.task {
 
     val DestDir: File = (Compile / resourceManaged).value / "templates"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -7,4 +7,4 @@
 ### (All comments with ### will be filtered out during template rendering)
 ### ----------------------------------------------------------------------
 
-sbt.version = 1.12.3
+sbt.version = 2.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
 //logLevel := Level.Debug
-resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.6")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.6.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"       % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"      % "1.11.2")


### PR DESCRIPTION
This upgrades the plugin to SBT2, and adds support for both Scala 3 and Scala 3LTS compilation. 